### PR TITLE
fix: remote.extensionKind

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "type": "git",
         "url": "https://github.com/swdotcom/swdc-vscode"
     },
-    "remote.extensionKind": {
+    "extensionKind": {
         "softwaredotcom.swdc-vscode": "ui"
     },
     "categories": [


### PR DESCRIPTION
remote.extensionKind is only valid on users `settings.json` file, on `package.json` file should be `extensionKind` [see](https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location)